### PR TITLE
Remove the `name` property

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const chalk = require('chalk');
 
 module.exports = function netlifyPlugin(conf) {
   return {
-    name: 'netlify-plugin-rss',
     /* index html files preDeploy */
     onPostBuild: async ({
       constants: { BUILD_DIR },


### PR DESCRIPTION
The `name` plugin property has been removed since it is redundant with the `name` in the `manifest.yml`.