### PR TITLE
Add `required` inputs to `manifest.yml`

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,8 +2,11 @@
 name: netlify-plugin-rss
 inputs:
   - name: dirToScan
+    required: true
   - name: authorName
+    required: true
   - name: site_url
+    required: true
   - name: feed_url
   - name: title
   - name: rssDescription

--- a/pluginCore.js
+++ b/pluginCore.js
@@ -11,10 +11,10 @@ const chalk = require('chalk');
 exports.generateRSS = async function(opts) {
   // combines scanDir and extractMetadataFromFile
   // returns RSS
-  const BUILD_DIR = required(opts, 'BUILD_DIR'); // eg 'publish'
-  const dirToScan = required(opts, 'dirToScan'); // eg '/blog'
-  const authorName = required(opts, 'authorName'); // eg 'myname'
-  const site_url = required(opts, 'site_url'); // eg 'https://swyx.io',
+  const BUILD_DIR = opts.BUILD_DIR; // eg 'publish'
+  const dirToScan = opts.dirToScan; // eg '/blog'
+  const authorName = opts.authorName; // eg 'myname'
+  const site_url = opts.site_url; // eg 'https://swyx.io',
   const feed_url = `${site_url}/rss.xml`; // may want to make this configurable in future
   const {
     title = opts.title || 'RSS Feed',
@@ -88,14 +88,6 @@ exports.generateRSS = async function(opts) {
   });
   return feed.xml();
 };
-
-function required(obj, key) {
-  if (typeof obj[key] === 'undefined') {
-    console.error('Error: ' + key + ' is required');
-    process.exit(1);
-  }
-  return obj[key];
-}
 
 exports.extractMetadataFromFile = async function({
   fileToRead,


### PR DESCRIPTION
Required inputs can now be put directly in the `manifest.yml`, providing with better error messages to users. This PR adds those.