### PR TITLE
Fix undefined variable reference

### DIFF
--- a/pluginCore.js
+++ b/pluginCore.js
@@ -18,7 +18,7 @@ exports.generateRSS = async function(opts) {
   const feed_url = `${site_url}/rss.xml`; // may want to make this configurable in future
   const {
     title,
-    description = opts.rssDescription || 'RSS Feed for ' + rssFeedUrl,
+    description = opts.rssDescription || 'RSS Feed for ' + site_url,
     image_url = opts.rssFaviconUrl,
     docs,
     managingEditor = authorName,


### PR DESCRIPTION
This fixes a variable reference which has a typo in its name, leading to any build failing unless the `rssDescription` input is defined with this plugin.